### PR TITLE
Remove unnecessary tag

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
             replicas: 1
             restart_policy:
                 condition: any
-        image: alejandrocolomar/https.alejandro-colomar.com:latest
+        image: alejandrocolomar/https.alejandro-colomar.com
         ports:
         -   80:80
 


### PR DESCRIPTION
It is unnecessary since we are not using tags anymore to identify the images. From now on it will be the latest or a specific digest.